### PR TITLE
Revert "Allow longer URLs due to increased Product Display Name length"

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -29,7 +29,7 @@
     <httpHandlers>
       <add verb="GET" path="sitemap.xml" type="Composite.AspNet.SiteMapHandler, Composite" />
     </httpHandlers>
-    <httpRuntime fcnMode="Single" targetFramework="4.7.1" maxRequestLength="20480" maxUrlLength="512" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
+    <httpRuntime fcnMode="Single" targetFramework="4.7.1" maxRequestLength="20480" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="&lt;,&gt;,*,%,&amp;,\,?" />
     <pages clientIDMode="AutoID">
       <controls>
         <add tagPrefix="c1" namespace="Composite.Plugins.PageTemplates.MasterPages.Controls.Rendering" assembly="Composite" />


### PR DESCRIPTION
This reverts commit 7dd6d1f9031737ece8faddc63bec05d8661f13b1.  The change is not needed at the C1 level.